### PR TITLE
Fix parameter in eNotasGWHelper function formatDateTime

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -6,7 +6,7 @@
 			return $date->format('Y-m-d');
 		}
 
-		public static function formatDateTime($dateTime) {
+		public static function formatDateTime($date) {
 			return $date->format('Y-m-d H:i:s');
 		}
 	}


### PR DESCRIPTION
Fix the mistyped parameter which was causing that the filter is not being generated properly by the buildUrl(), by causing a fatal error when calling "$date->format" method on a string.